### PR TITLE
setAutoMeasureEnable(true),support wrap_content

### DIFF
--- a/VegaLayoutManager/.gitignore
+++ b/VegaLayoutManager/.gitignore
@@ -1,9 +1,8 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
 .DS_Store
 /build
 /captures
 .externalNativeBuild
+.idea/

--- a/VegaLayoutManager/app/src/main/res/layout/activity_main.xml
+++ b/VegaLayoutManager/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,6 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/main_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/VegaLayoutManager/library/src/main/java/com/stone/vega/library/VegaLayoutManager.java
+++ b/VegaLayoutManager/library/src/main/java/com/stone/vega/library/VegaLayoutManager.java
@@ -24,6 +24,10 @@ public class VegaLayoutManager extends RecyclerView.LayoutManager {
     private RecyclerView.Adapter adapter;
     private RecyclerView.Recycler recycler;
 
+    public VegaLayoutManager() {
+        setAutoMeasureEnabled(true);
+    }
+
     @Override
     public RecyclerView.LayoutParams generateDefaultLayoutParams() {
         return new RecyclerView.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);


### PR DESCRIPTION
app 里面的例子 布局里面的RecyclerView 宽高都是match_parent,可以正常显示,,但是设置成wrap_content是不会显示任何item的，这是因为VegaLayoutManager 自己接管了测量，但是却没有实现具体的测量逻辑，最后还是调用了RV的defaultOnMeasure方法，导致最后RV没有宽高（如果RV没有设置padding和最小宽高）；解决办法是可以通过调用LayoutManager的setAutoMeasureEnabled(true)让RV接管测量，这样在使用VegaLayoutManager时候RV会处理wrap_content. 具体查看RV源码的onMeasure方法，希望采纳！